### PR TITLE
Fix NetworkManager config

### DIFF
--- a/src/pia/applications/template-configs/nm.cfg
+++ b/src/pia/applications/template-configs/nm.cfg
@@ -16,6 +16,7 @@ remote-cert-tls=server
 ca=/etc/openvpn/ca.rsa.2048.crt
 dev=tun
 proto-tcp=##use-tcp##
+cipher=##cipher##
 
 [ipv6]
 method=auto


### PR DESCRIPTION
This PR switches the config for NetworkMangager to AES-128-CBC instead of Default (which renders the interwebs unusable as per [various comments in the AUR](https://aur.archlinux.org/packages/private-internet-access-vpn/?comments=all)
