### PR TITLE
NetworkManager lib path + indentation error

### DIFF
--- a/src/pia/applications/hooks.py
+++ b/src/pia/applications/hooks.py
@@ -93,7 +93,7 @@ class ApplicationStrategyNM(StrategicAlternative):
         @conf_dir: directory to the application stores it's configurations
     """
     _CONF_DIR = '/etc/NetworkManager/system-connections'
-    _COMMAND_BIN = ['/usr/bin/nmcli', '/usr/lib/networkmanager/nm-openvpn-service']
+    _COMMAND_BIN = ['/usr/bin/nmcli', '/usr/lib/NetworkManager/nm-openvpn-service']
 
     def __init__(self):
         super().__init__('nm')

--- a/src/pia/run.py
+++ b/src/pia/run.py
@@ -175,7 +175,7 @@ def list_configurations():
                     config['apps'] += '[' + app_name + ']'
         configs[c] = config
 
-        print("List of OpenVPN configurations")
+    print("List of OpenVPN configurations")
     for c in configs:
         if configs[c]['openvpn']:
             print('  {openvpn} {host} {apps}'.format(**configs[c]))


### PR DESCRIPTION
- nm-openvpn-service is located in /usr/lib/NetworkManager/ directory
- List of OpenVPN configurations was printed inside the previous loop

#28 